### PR TITLE
feat(dashboard): implement interactive monitoring UI

### DIFF
--- a/dashboard-web/src/app.js
+++ b/dashboard-web/src/app.js
@@ -1,0 +1,1009 @@
+const state = {
+  connection: {
+    orchestratorUrl: '',
+    loggingUrl: '',
+    echoUrl: '',
+    renderctlUrl: ''
+  },
+  auth: {
+    username: '',
+    password: ''
+  },
+  authHeader: null,
+  tasks: new Map(),
+  taskDetails: new Map(),
+  taskEvents: new Map(),
+  selectedTaskId: null,
+  activity: [],
+  logs: [],
+  configReports: [],
+  tasksFilter: 'all',
+  ws: null,
+  isConnected: false
+};
+
+const elements = {};
+
+const STORAGE_KEY = 'pao-dashboard-settings';
+const MAX_ACTIVITY = 80;
+const MAX_LOGS = 80;
+const MAX_EVENTS = 80;
+
+document.addEventListener('DOMContentLoaded', init);
+
+function init() {
+  cacheElements();
+  bindEvents();
+  loadSettings();
+  setDefaultPayload();
+  renderTasks();
+  renderTaskDetail();
+  renderActivity();
+  renderLogs();
+  renderConfig();
+}
+
+function cacheElements() {
+  elements.statusBanner = document.getElementById('status-banner');
+  elements.connectionForm = document.getElementById('connection-form');
+  elements.connectButton = document.getElementById('connect-button');
+  elements.disconnectButton = document.getElementById('disconnect-button');
+  elements.clearSettingsButton = document.getElementById('clear-settings');
+  elements.orchestratorInput = document.getElementById('orchestrator-url');
+  elements.loggingInput = document.getElementById('logging-url');
+  elements.echoInput = document.getElementById('echo-url');
+  elements.renderctlInput = document.getElementById('renderctl-url');
+  elements.usernameInput = document.getElementById('auth-username');
+  elements.passwordInput = document.getElementById('auth-password');
+  elements.taskForm = document.getElementById('task-form');
+  elements.taskTypeInput = document.getElementById('task-type');
+  elements.taskSourceInput = document.getElementById('task-source');
+  elements.taskCorrelationInput = document.getElementById('task-correlation');
+  elements.taskPayloadInput = document.getElementById('task-payload');
+  elements.taskFeedback = document.getElementById('task-feedback');
+  elements.resetPayloadButton = document.getElementById('reset-payload');
+  elements.taskFilter = document.getElementById('task-filter');
+  elements.refreshTasksButton = document.getElementById('refresh-tasks');
+  elements.tasksTableBody = document.getElementById('tasks-tbody');
+  elements.refreshDetailButton = document.getElementById('refresh-detail');
+  elements.taskDetail = document.getElementById('task-detail');
+  elements.activityList = document.getElementById('activity-list');
+  elements.logsList = document.getElementById('logs-list');
+  elements.refreshConfigButton = document.getElementById('refresh-config');
+  elements.configResults = document.getElementById('config-results');
+}
+
+function bindEvents() {
+  elements.connectionForm?.addEventListener('submit', handleConnect);
+  elements.disconnectButton?.addEventListener('click', handleDisconnect);
+  elements.clearSettingsButton?.addEventListener('click', handleClearSettings);
+  elements.taskForm?.addEventListener('submit', handleCreateTask);
+  elements.resetPayloadButton?.addEventListener('click', (event) => {
+    event.preventDefault();
+    setDefaultPayload();
+  });
+  elements.taskFilter?.addEventListener('change', (event) => {
+    state.tasksFilter = event.target.value;
+    renderTasks();
+  });
+  elements.refreshTasksButton?.addEventListener('click', () => {
+    refreshTasks();
+  });
+  elements.tasksTableBody?.addEventListener('click', handleTaskTableClick);
+  elements.refreshDetailButton?.addEventListener('click', () => {
+    if (state.selectedTaskId) {
+      fetchTaskDetail(state.selectedTaskId, { showStatus: true });
+    }
+  });
+  elements.taskDetail?.addEventListener('click', handleTaskDetailClick);
+  elements.refreshConfigButton?.addEventListener('click', () => {
+    refreshConfig();
+  });
+  window.addEventListener('beforeunload', () => {
+    closeWebsocket();
+  });
+}
+
+function loadSettings() {
+  let stored = null;
+  try {
+    stored = window.localStorage?.getItem(STORAGE_KEY) || null;
+  } catch (err) {
+    console.warn('Failed to read stored settings', err);
+  }
+  if (stored) {
+    try {
+      const parsed = JSON.parse(stored);
+      if (parsed.connection) {
+        Object.assign(state.connection, parsed.connection);
+      }
+      if (parsed.username) {
+        state.auth.username = parsed.username;
+      }
+    } catch (err) {
+      console.warn('Stored settings were not valid JSON', err);
+    }
+  }
+  applySettingsToForm();
+}
+
+function applySettingsToForm() {
+  if (elements.orchestratorInput) {
+    elements.orchestratorInput.value = state.connection.orchestratorUrl || 'http://localhost:4000';
+  }
+  if (elements.loggingInput) {
+    elements.loggingInput.value = state.connection.loggingUrl || '';
+  }
+  if (elements.echoInput) {
+    elements.echoInput.value = state.connection.echoUrl || '';
+  }
+  if (elements.renderctlInput) {
+    elements.renderctlInput.value = state.connection.renderctlUrl || '';
+  }
+  if (elements.usernameInput) {
+    elements.usernameInput.value = state.auth.username || '';
+  }
+  if (elements.passwordInput) {
+    elements.passwordInput.value = '';
+  }
+}
+
+function saveSettings() {
+  try {
+    window.localStorage?.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        connection: state.connection,
+        username: state.auth.username || ''
+      })
+    );
+  } catch (err) {
+    console.warn('Failed to persist settings', err);
+  }
+}
+
+function handleClearSettings(event) {
+  event.preventDefault();
+  try {
+    window.localStorage?.removeItem(STORAGE_KEY);
+  } catch (err) {
+    console.warn('Failed to clear stored settings', err);
+  }
+  state.connection = {
+    orchestratorUrl: '',
+    loggingUrl: '',
+    echoUrl: '',
+    renderctlUrl: ''
+  };
+  state.auth.username = '';
+  state.auth.password = '';
+  state.authHeader = null;
+  applySettingsToForm();
+  setDefaultPayload();
+  setStatus('Saved settings cleared. Update the connection details to reconnect.', 'pending');
+  addActivity({ label: 'Cleared saved connection settings', level: 'info' });
+}
+
+function setDefaultPayload() {
+  if (!elements.taskPayloadInput) return;
+  const example = {
+    message: 'Hello from the dashboard',
+    ts: new Date().toISOString()
+  };
+  elements.taskPayloadInput.value = JSON.stringify(example, null, 2);
+}
+
+async function handleConnect(event) {
+  event.preventDefault();
+  if (!elements.connectionForm) return;
+  const formData = new FormData(elements.connectionForm);
+  const orchestratorUrl = (formData.get('orchestratorUrl') || '').trim();
+
+  if (!orchestratorUrl) {
+    setStatus('Orchestrator URL is required to connect.', 'error');
+    return;
+  }
+
+  state.connection.orchestratorUrl = orchestratorUrl;
+  state.connection.loggingUrl = (formData.get('loggingUrl') || '').trim();
+  state.connection.echoUrl = (formData.get('echoUrl') || '').trim();
+  state.connection.renderctlUrl = (formData.get('renderctlUrl') || '').trim();
+  state.auth.username = (formData.get('username') || '').trim();
+  state.auth.password = formData.get('password') || '';
+  state.authHeader = state.auth.username && state.auth.password ? encodeBasicAuth(state.auth.username, state.auth.password) : null;
+
+  saveSettings();
+  disableConnectionInputs(true);
+  setStatus('Connecting to orchestrator…', 'pending');
+  addActivity({ label: 'Attempting connection to orchestrator', level: 'info' });
+
+  try {
+    await checkOrchestratorHealth();
+    state.isConnected = true;
+    setStatus(`Connected to ${state.connection.orchestratorUrl}`, 'ok');
+    addActivity({ label: 'Connected to orchestrator', level: 'success' });
+    await Promise.allSettled([refreshTasks(), refreshConfig(), loadRecentLogs()]);
+    startWebsocket();
+  } catch (err) {
+    console.error('Connection failed', err);
+    state.isConnected = false;
+    setStatus(`Connection failed: ${err.message}`, 'error');
+    addActivity({ label: 'Connection failed', level: 'error', context: err.message });
+  } finally {
+    disableConnectionInputs(false);
+  }
+}
+
+function handleDisconnect(event) {
+  event?.preventDefault();
+  if (!state.isConnected && !state.ws) {
+    return;
+  }
+  disconnect();
+  setStatus('Disconnected.', 'pending');
+  addActivity({ label: 'Disconnected from orchestrator', level: 'warn' });
+}
+
+async function handleCreateTask(event) {
+  event.preventDefault();
+  if (!state.connection.orchestratorUrl) {
+    setTaskFeedback('Connect to the orchestrator first.', 'error');
+    return;
+  }
+  if (!elements.taskForm) return;
+
+  const formData = new FormData(elements.taskForm);
+  const type = (formData.get('type') || '').trim();
+  const source = (formData.get('source') || '').trim();
+  const correlationId = (formData.get('correlationId') || '').trim();
+  const payloadText = formData.get('payload') || '';
+
+  if (!type) {
+    setTaskFeedback('Task type is required.', 'error');
+    return;
+  }
+  if (!source) {
+    setTaskFeedback('Source is required.', 'error');
+    return;
+  }
+
+  let payload = {};
+  if (payloadText.trim()) {
+    try {
+      payload = JSON.parse(payloadText);
+    } catch (err) {
+      setTaskFeedback(`Payload must be valid JSON: ${err.message}`, 'error');
+      return;
+    }
+  }
+
+  try {
+    const result = await apiRequest(state.connection.orchestratorUrl, '/task', {
+      method: 'POST',
+      body: {
+        type,
+        source,
+        payload,
+        correlationId: correlationId || undefined
+      }
+    });
+    const taskId = result?.id;
+    setTaskFeedback(`Task ${taskId ? shortId(taskId) : ''} enqueued.`, 'success');
+    addActivity({ label: `Created task ${taskId ? shortId(taskId) : ''}`, level: 'success', context: { type, source } });
+    await refreshTasks({ silent: true });
+  } catch (err) {
+    console.error('Failed to create task', err);
+    setTaskFeedback(`Failed to create task: ${err.message}`, 'error');
+    addActivity({ label: 'Task creation failed', level: 'error', context: err.message });
+  }
+}
+
+
+function handleTaskTableClick(event) {
+  const target = event.target.closest('[data-action]');
+  if (!target) return;
+  const taskId = target.getAttribute('data-task-id');
+  if (!taskId) return;
+  if (target.dataset.action === 'view-task') {
+    selectTask(taskId);
+  }
+}
+
+function handleTaskDetailClick(event) {
+  const target = event.target.closest('[data-action]');
+  if (!target) return;
+  const taskId = target.getAttribute('data-task-id');
+  if (!taskId) return;
+  if (target.dataset.action === 'refresh-detail') {
+    fetchTaskDetail(taskId, { showStatus: true });
+  }
+}
+
+function selectTask(taskId) {
+  state.selectedTaskId = taskId;
+  renderTasks();
+  if (elements.taskDetail) {
+    elements.taskDetail.innerHTML = '<p class="hint">Loading task detail…</p>';
+  }
+  fetchTaskDetail(taskId);
+}
+
+function disconnect() {
+  state.isConnected = false;
+  closeWebsocket();
+  state.tasks.clear();
+  state.taskDetails.clear();
+  state.taskEvents.clear();
+  state.selectedTaskId = null;
+  renderTasks();
+  renderTaskDetail();
+}
+
+function disableConnectionInputs(disabled) {
+  const controls = [
+    elements.connectButton,
+    elements.disconnectButton,
+    elements.clearSettingsButton,
+    elements.orchestratorInput,
+    elements.loggingInput,
+    elements.echoInput,
+    elements.renderctlInput,
+    elements.usernameInput,
+    elements.passwordInput
+  ];
+  controls.forEach((el) => {
+    if (el) {
+      el.disabled = disabled;
+    }
+  });
+}
+
+function encodeBasicAuth(username, password) {
+  if (typeof btoa === 'function') {
+    return `Basic ${btoa(`${username}:${password}`)}`;
+  }
+  return null;
+}
+
+async function checkOrchestratorHealth() {
+  const response = await apiRequest(state.connection.orchestratorUrl, '/health');
+  if (!response || response.status !== 'ok') {
+    throw new Error('Health check failed');
+  }
+}
+
+async function refreshTasks(options = {}) {
+  if (!state.connection.orchestratorUrl) return;
+  try {
+    const result = await apiRequest(state.connection.orchestratorUrl, '/tasks?limit=50');
+    const tasks = Array.isArray(result?.tasks) ? result.tasks : [];
+    state.tasks.clear();
+    tasks.forEach((task) => {
+      if (task?.id) {
+        state.tasks.set(task.id, task);
+      }
+    });
+    renderTasks();
+    if (state.selectedTaskId) {
+      renderTaskDetail(state.selectedTaskId);
+    }
+  } catch (err) {
+    if (!options.silent) {
+      setStatus(`Failed to fetch tasks: ${err.message}`, 'error');
+      addActivity({ label: 'Failed to fetch tasks', level: 'error', context: err.message });
+    }
+  }
+}
+
+async function fetchTaskDetail(taskId, options = {}) {
+  if (!taskId || !state.connection.orchestratorUrl) return;
+  try {
+    const detail = await apiRequest(state.connection.orchestratorUrl, `/task/${encodeURIComponent(taskId)}`);
+    if (detail?.task) {
+      state.tasks.set(detail.task.id, detail.task);
+      state.taskDetails.set(taskId, detail);
+      mergeTaskEvents(taskId, detail.events || []);
+      renderTasks();
+      renderTaskDetail(taskId);
+      if (options.showStatus) {
+        setStatus(`Task ${shortId(taskId)} refreshed.`, 'ok');
+      }
+    }
+  } catch (err) {
+    console.error('Failed to fetch task detail', err);
+    setStatus(`Failed to fetch task detail: ${err.message}`, 'error');
+    addActivity({ label: 'Failed to fetch task detail', level: 'error', context: err.message });
+  }
+}
+
+function mergeTaskEvents(taskId, events) {
+  if (!Array.isArray(events)) return;
+  const existing = state.taskEvents.get(taskId) || [];
+  const map = new Map(existing.map((evt) => [evt.id, evt]));
+  events.map((evt) => normalizeTaskEvent(evt)).forEach((evt) => {
+    if (evt) {
+      map.set(evt.id, evt);
+    }
+  });
+  const merged = Array.from(map.values()).sort((a, b) => new Date(a.ts) - new Date(b.ts));
+  const trimmed = merged.length > MAX_EVENTS ? merged.slice(merged.length - MAX_EVENTS) : merged;
+  state.taskEvents.set(taskId, trimmed);
+}
+
+function startWebsocket() {
+  if (!state.connection.orchestratorUrl) return;
+  closeWebsocket();
+  let wsUrl;
+  try {
+    wsUrl = buildWsUrl(state.connection.orchestratorUrl);
+  } catch (err) {
+    console.error('Failed to construct websocket URL', err);
+    addActivity({ label: 'WebSocket URL invalid', level: 'error', context: err.message });
+    return;
+  }
+  const socket = new WebSocket(wsUrl);
+  socket.onopen = () => {
+    addActivity({ label: 'WebSocket connected', level: 'success' });
+  };
+  socket.onmessage = (event) => {
+    handleWebsocketMessage(event.data);
+  };
+  socket.onerror = (event) => {
+    console.error('WebSocket error', event);
+    addActivity({ label: 'WebSocket error', level: 'error' });
+  };
+  socket.onclose = () => {
+    addActivity({ label: 'WebSocket disconnected', level: 'warn' });
+    state.ws = null;
+  };
+  state.ws = socket;
+}
+
+function closeWebsocket() {
+  if (state.ws) {
+    try {
+      state.ws.close();
+    } catch (err) {
+      console.warn('Error closing websocket', err);
+    }
+  }
+  state.ws = null;
+}
+
+function buildWsUrl(baseUrl) {
+  const url = new URL(resolveUrl(baseUrl, 'ws'));
+  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+  return url.toString();
+}
+
+function handleWebsocketMessage(payload) {
+  let frame;
+  try {
+    frame = JSON.parse(payload);
+  } catch (err) {
+    console.error('Failed to parse websocket payload', err);
+    return;
+  }
+  if (!frame || !frame.type) return;
+  const timestamp = frame.ts || new Date().toISOString();
+
+  if (frame.type === 'TASK_UPDATE' && frame.data?.task) {
+    const task = frame.data.task;
+    state.tasks.set(task.id, task);
+    renderTasks();
+    if (state.selectedTaskId === task.id) {
+      renderTaskDetail(task.id);
+    }
+    addActivity({
+      ts: timestamp,
+      label: `Task ${shortId(task.id)} → ${task.status}`,
+      level: task.status === 'error' ? 'error' : task.status === 'done' ? 'success' : 'info',
+      context: { id: task.id, status: task.status }
+    });
+    return;
+  }
+
+  if (frame.type === 'TASK_EVENT' && frame.data) {
+    storeTaskEvent(frame.data, timestamp);
+    return;
+  }
+
+  if (frame.type === 'LOG' && frame.data) {
+    storeLogEntry(frame.data, timestamp);
+    return;
+  }
+
+  addActivity({ ts: timestamp, label: `Received ${frame.type} frame`, level: 'info' });
+}
+
+function storeTaskEvent(rawEvent, fallbackTs) {
+  const event = normalizeTaskEvent(rawEvent, fallbackTs);
+  if (!event) return;
+  const events = state.taskEvents.get(event.taskId) || [];
+  if (!events.find((existing) => existing.id === event.id)) {
+    events.push(event);
+    events.sort((a, b) => new Date(a.ts) - new Date(b.ts));
+    if (events.length > MAX_EVENTS) {
+      events.splice(0, events.length - MAX_EVENTS);
+    }
+    state.taskEvents.set(event.taskId, events);
+  }
+  addActivity({
+    ts: event.ts,
+    label: `Event · ${event.kind} (${shortId(event.taskId)})`,
+    level: event.kind === 'error' ? 'error' : 'info',
+    context: event.data || null
+  });
+  if (state.selectedTaskId === event.taskId) {
+    renderTaskDetail(event.taskId);
+  }
+}
+
+function normalizeTaskEvent(rawEvent, fallbackTs) {
+  if (!rawEvent) return null;
+  const taskId = rawEvent.taskId || rawEvent.task_id;
+  if (!taskId) return null;
+  const ts = rawEvent.ts || rawEvent.ts_utc || fallbackTs || new Date().toISOString();
+  const id = rawEvent.id || `${taskId}-${rawEvent.kind || 'event'}-${ts}`;
+  return {
+    id,
+    taskId,
+    ts,
+    actor: rawEvent.actor || 'unknown',
+    kind: rawEvent.kind || 'event',
+    data: rawEvent.data ?? null
+  };
+}
+
+function storeLogEntry(rawLog, fallbackTs) {
+  const log = normalizeLog(rawLog, fallbackTs);
+  if (!log) return;
+  if (!state.logs.find((existing) => existing.id === log.id)) {
+    state.logs.unshift(log);
+    if (state.logs.length > MAX_LOGS) {
+      state.logs.length = MAX_LOGS;
+    }
+    renderLogs();
+  }
+  addActivity({
+    ts: log.ts,
+    label: `Log · ${log.service || 'unknown'} (${log.level})`,
+    level: log.level === 'error' ? 'error' : log.level === 'warn' ? 'warn' : 'info',
+    context: log.message
+  });
+}
+
+function normalizeLog(rawLog, fallbackTs) {
+  if (!rawLog) return null;
+  const ts = rawLog.ts_utc || rawLog.ts || fallbackTs || new Date().toISOString();
+  const id = rawLog.id || `${rawLog.service || 'log'}-${ts}-${rawLog.message || ''}`;
+  return {
+    id,
+    ts,
+    service: rawLog.service || 'log',
+    level: (rawLog.level || 'info').toLowerCase(),
+    message: rawLog.message || '',
+    traceId: rawLog.trace_id || rawLog.traceId || null,
+    correlationId: rawLog.correlation_id || rawLog.correlationId || null,
+    taskId: rawLog.task_id || rawLog.taskId || null,
+    data: rawLog.data ?? null
+  };
+}
+
+async function loadRecentLogs() {
+  if (!state.connection.loggingUrl) return;
+  try {
+    const response = await apiRequest(state.connection.loggingUrl, '/logs?limit=50');
+    const logs = Array.isArray(response?.logs) ? response.logs.map((item) => normalizeLog(item)).filter(Boolean) : [];
+    logs.sort((a, b) => new Date(b.ts) - new Date(a.ts));
+    state.logs = logs.slice(0, MAX_LOGS);
+    renderLogs();
+  } catch (err) {
+    console.warn('Failed to load log history', err);
+    addActivity({ label: 'Failed to load log history', level: 'warn', context: err.message });
+  }
+}
+
+
+async function refreshConfig() {
+  const services = gatherServiceEndpoints();
+  if (!services.length) {
+    state.configReports = [];
+    renderConfig();
+    return;
+  }
+
+  const results = await Promise.all(
+    services.map(async (service) => {
+      try {
+        const report = await apiRequest(service.baseUrl, '/config/validate');
+        return { serviceName: report?.service || service.name, baseUrl: service.baseUrl, report };
+      } catch (err) {
+        return { serviceName: service.name, baseUrl: service.baseUrl, error: err };
+      }
+    })
+  );
+
+  state.configReports = results;
+  renderConfig();
+}
+
+function gatherServiceEndpoints() {
+  const endpoints = [];
+  if (state.connection.orchestratorUrl) {
+    endpoints.push({ name: 'orchestrator-svc', baseUrl: state.connection.orchestratorUrl });
+  }
+  if (state.connection.loggingUrl) {
+    endpoints.push({ name: 'logging-svc', baseUrl: state.connection.loggingUrl });
+  }
+  if (state.connection.echoUrl) {
+    endpoints.push({ name: 'echo-agent-svc', baseUrl: state.connection.echoUrl });
+  }
+  if (state.connection.renderctlUrl) {
+    endpoints.push({ name: 'renderctl-svc', baseUrl: state.connection.renderctlUrl });
+  }
+  return endpoints;
+}
+
+function renderTasks() {
+  if (!elements.tasksTableBody) return;
+  const tasks = Array.from(state.tasks.values());
+  tasks.sort((a, b) => new Date(b.updated_at || b.created_at || 0) - new Date(a.updated_at || a.created_at || 0));
+  const filtered = state.tasksFilter === 'all' ? tasks : tasks.filter((task) => task.status === state.tasksFilter);
+
+  if (!filtered.length) {
+    elements.tasksTableBody.innerHTML =
+      '<tr class="empty"><td colspan="7">No tasks yet. Create one above to get started.</td></tr>';
+    return;
+  }
+
+  const rows = filtered
+    .map((task) => {
+      const rowClass = state.selectedTaskId === task.id ? 'is-selected' : '';
+      return `<tr data-task-id="${task.id}" class="${rowClass}">
+          <td><span class="mono" title="${escapeHtml(task.id)}">${escapeHtml(shortId(task.id))}</span></td>
+          <td>${renderStatusPill(task.status)}</td>
+          <td>${escapeHtml(task.type || '—')}</td>
+          <td>${escapeHtml(task.source || '—')}</td>
+          <td>${escapeHtml(formatDateTime(task.updated_at || task.created_at))}</td>
+          <td>${typeof task.version === 'number' ? task.version : '—'}</td>
+          <td><button class="button ghost" data-action="view-task" data-task-id="${task.id}">Inspect</button></td>
+        </tr>`;
+    })
+    .join('');
+
+  elements.tasksTableBody.innerHTML = rows;
+}
+
+function renderStatusPill(status) {
+  const normalized = sanitizeStatus(status);
+  return `<span class="pill status-${normalized}">${escapeHtml(normalized)}</span>`;
+}
+
+function renderTaskDetail(taskId = state.selectedTaskId) {
+  if (!elements.taskDetail) return;
+  if (!taskId) {
+    elements.taskDetail.innerHTML = '<p class="hint">Select a task from the table to inspect payloads, results, and event history.</p>';
+    return;
+  }
+  const task = state.tasks.get(taskId) || state.taskDetails.get(taskId)?.task;
+  if (!task) {
+    elements.taskDetail.innerHTML = '<p class="hint">Task not found. Refresh tasks to sync the dashboard.</p>';
+    return;
+  }
+  const events = getTaskEvents(taskId);
+  const eventsMarkup = events.length
+    ? `<ul class="bullet-list">${events
+        .map(
+          (event) => `<li>
+              <strong>${escapeHtml(event.kind)}</strong> · ${escapeHtml(event.actor)} · ${escapeHtml(formatDateTime(event.ts))}
+              ${event.data !== null && event.data !== undefined ? `<pre class="json-block">${escapeHtml(formatJson(event.data))}</pre>` : ''}
+            </li>`
+        )
+        .join('')}</ul>`
+    : '<p class="hint">No events recorded yet.</p>';
+  const payloadBlock = `<pre class="json-block">${escapeHtml(formatJson(task.payload || {}))}</pre>`;
+  const resultBlock =
+    task.result !== null && task.result !== undefined
+      ? `<pre class="json-block">${escapeHtml(formatJson(task.result))}</pre>`
+      : '<p class="hint">No result recorded.</p>';
+  const errorBlock =
+    task.error !== null && task.error !== undefined
+      ? `<pre class="json-block">${escapeHtml(formatJson(task.error))}</pre>`
+      : '<p class="hint">No error payload.</p>';
+
+  elements.taskDetail.innerHTML = `
+    <div class="detail-meta">
+      <div class="detail-row"><span class="label">ID</span><span class="mono">${escapeHtml(task.id)}</span></div>
+      <div class="detail-row"><span class="label">Status</span><span>${renderStatusPill(task.status)}</span></div>
+      <div class="detail-row"><span class="label">Trace ID</span><span class="mono">${escapeHtml(task.trace_id || task.traceId || '—')}</span></div>
+      <div class="detail-row"><span class="label">Correlation</span><span class="mono">${escapeHtml(task.correlation_id || task.correlationId || '—')}</span></div>
+      <div class="detail-row"><span class="label">Created</span><span>${escapeHtml(formatDateTime(task.created_at))}</span></div>
+      <div class="detail-row"><span class="label">Updated</span><span>${escapeHtml(formatDateTime(task.updated_at))}</span></div>
+    </div>
+    <div class="detail-actions">
+      <button class="button" data-action="refresh-detail" data-task-id="${task.id}">Refresh</button>
+    </div>
+    <div class="detail-section">
+      <h3>Payload</h3>
+      ${payloadBlock}
+    </div>
+    <div class="detail-section">
+      <h3>Result</h3>
+      ${resultBlock}
+    </div>
+    <div class="detail-section">
+      <h3>Error</h3>
+      ${errorBlock}
+    </div>
+    <div class="detail-section">
+      <h3>Events</h3>
+      ${eventsMarkup}
+    </div>
+  `;
+}
+
+function getTaskEvents(taskId) {
+  const detailEvents = state.taskDetails.get(taskId)?.events || [];
+  const normalizedDetail = detailEvents.map((evt) => normalizeTaskEvent(evt)).filter(Boolean);
+  const streamEvents = state.taskEvents.get(taskId) || [];
+  const map = new Map();
+  normalizedDetail.forEach((evt) => map.set(evt.id, evt));
+  streamEvents.forEach((evt) => map.set(evt.id, evt));
+  return Array.from(map.values()).sort((a, b) => new Date(a.ts) - new Date(b.ts));
+}
+
+function renderActivity() {
+  if (!elements.activityList) return;
+  if (!state.activity.length) {
+    elements.activityList.innerHTML = '<li class="timeline__item timeline__item--empty">No activity yet.</li>';
+    return;
+  }
+  const items = state.activity
+    .map(
+      (entry) => `<li class="timeline__item">
+          <div class="timeline__ts">${escapeHtml(formatTime(entry.ts))}</div>
+          <div class="timeline__content">
+            <div class="timeline__label">${escapeHtml(entry.label)}</div>
+            ${renderActivityContext(entry.context)}
+          </div>
+        </li>`
+    )
+    .join('');
+  elements.activityList.innerHTML = items;
+}
+
+function addActivity(entry) {
+  const normalized = {
+    ts: entry.ts || new Date().toISOString(),
+    label: entry.label || 'Activity',
+    level: entry.level || 'info',
+    context: entry.context ?? null
+  };
+  state.activity.unshift(normalized);
+  if (state.activity.length > MAX_ACTIVITY) {
+    state.activity.length = MAX_ACTIVITY;
+  }
+  renderActivity();
+}
+
+function renderActivityContext(context) {
+  if (context === null || context === undefined || context === '') {
+    return '';
+  }
+  if (typeof context === 'string') {
+    return `<p class="timeline__text">${escapeHtml(context)}</p>`;
+  }
+  return `<details class="timeline__details"><summary>Details</summary><pre>${escapeHtml(formatJson(context))}</pre></details>`;
+}
+
+function renderLogs() {
+  if (!elements.logsList) return;
+  if (!state.logs.length) {
+    elements.logsList.innerHTML = '<li class="timeline__item timeline__item--empty">No logs yet.</li>';
+    return;
+  }
+  const items = state.logs
+    .map(
+      (log) => `<li class="timeline__item">
+          <div class="timeline__ts">${escapeHtml(formatTime(log.ts))}</div>
+          <div class="timeline__content">
+            <div class="timeline__label">
+              <span class="pill log-level-${escapeHtml(log.level)}">${escapeHtml(log.level)}</span>
+              <span class="mono">${escapeHtml(log.service || 'log')}</span>
+            </div>
+            <p class="timeline__text">${escapeHtml(log.message || '')}</p>
+            ${renderLogDetails(log)}
+          </div>
+        </li>`
+    )
+    .join('');
+  elements.logsList.innerHTML = items;
+}
+
+
+function renderLogDetails(log) {
+  const meta = [];
+  if (log.traceId) meta.push(`trace ${log.traceId}`);
+  if (log.correlationId) meta.push(`corr ${log.correlationId}`);
+  if (log.taskId) meta.push(`task ${log.taskId}`);
+  const metaHtml = meta.length ? `<p class="timeline__text">${escapeHtml(meta.join(' · '))}</p>` : '';
+  const dataHtml =
+    log.data !== null && log.data !== undefined
+      ? `<details class="timeline__details"><summary>Payload</summary><pre>${escapeHtml(formatJson(log.data))}</pre></details>`
+      : '';
+  return `${metaHtml}${dataHtml}`;
+}
+
+function renderConfig() {
+  if (!elements.configResults) return;
+  if (!state.configReports.length) {
+    elements.configResults.innerHTML =
+      '<p class="hint">Provide base URLs above and run validation to inspect each service's configuration status.</p>';
+    return;
+  }
+  const cards = state.configReports
+    .map((entry) => {
+      if (entry.error) {
+        return `<div class="config-card config-card--error">
+            <div class="config-card__header">
+              <div>
+                <h3>${escapeHtml(entry.serviceName)}</h3>
+                <p class="config-card__url">${escapeHtml(entry.baseUrl)}</p>
+              </div>
+              <span class="pill status-error">ERROR</span>
+            </div>
+            <p class="timeline__text">${escapeHtml(entry.error.message || 'Unable to fetch report')}</p>
+          </div>`;
+      }
+      const report = entry.report || {};
+      const missingRequired = Object.entries(report.required || {})
+        .filter(([, status]) => status !== 'present')
+        .map(([key]) => key);
+      const errors = Array.isArray(report.errors) ? report.errors : [];
+      const status = sanitizeStatus(report.status || 'unknown');
+      return `<div class="config-card ${report.status === 'ok' ? '' : 'config-card--error'}">
+          <div class="config-card__header">
+            <div>
+              <h3>${escapeHtml(entry.serviceName)}</h3>
+              <p class="config-card__url">${escapeHtml(entry.baseUrl)}</p>
+            </div>
+            <span class="pill status-${status}">${escapeHtml(status.toUpperCase())}</span>
+          </div>
+          <div class="detail-section">
+            <h3>Required keys</h3>
+            ${
+              missingRequired.length
+                ? `<ul class="bullet-list">${missingRequired.map((key) => `<li>${escapeHtml(key)}</li>`).join('')}</ul>`
+                : '<p class="hint">All required keys present.</p>'
+            }
+          </div>
+          <div class="detail-section">
+            <h3>Validation errors</h3>
+            ${
+              errors.length
+                ? `<ul class="bullet-list">${errors
+                    .map((err) => `<li>${escapeHtml(`${err.instancePath || '/'} ${err.message || ''}`.trim())}</li>`)
+                    .join('')}</ul>`
+                : '<p class="hint">No schema violations detected.</p>'
+            }
+          </div>
+        </div>`;
+    })
+    .join('');
+  elements.configResults.innerHTML = cards;
+}
+
+function setTaskFeedback(message, variant) {
+  if (!elements.taskFeedback) return;
+  const classes = ['feedback', 'is-visible'];
+  if (variant === 'success') classes.push('success');
+  if (variant === 'error') classes.push('error');
+  elements.taskFeedback.className = classes.join(' ');
+  elements.taskFeedback.textContent = message;
+}
+
+function setStatus(message, variant) {
+  if (!elements.statusBanner) return;
+  const classes = ['status-banner'];
+  if (variant === 'ok') classes.push('status-ok');
+  if (variant === 'error') classes.push('status-error');
+  if (variant === 'pending') classes.push('status-pending');
+  elements.statusBanner.className = classes.join(' ');
+  elements.statusBanner.textContent = message;
+}
+
+async function apiRequest(baseUrl, path, options = {}) {
+  if (!baseUrl) {
+    throw new Error('Base URL is not configured');
+  }
+  const target = resolveUrl(baseUrl, path || '');
+  const headers = Object.assign({}, options.headers || {});
+  if (options.body !== undefined) {
+    headers['Content-Type'] = 'application/json';
+  }
+  headers.Accept = headers.Accept || 'application/json';
+  if (state.authHeader) {
+    headers.Authorization = state.authHeader;
+  }
+
+  const response = await fetch(target, {
+    method: options.method || (options.body ? 'POST' : 'GET'),
+    headers,
+    body: options.body !== undefined ? JSON.stringify(options.body) : undefined
+  });
+  const contentType = response.headers.get('content-type') || '';
+  const text = await response.text();
+
+  if (!response.ok) {
+    throw new Error(text || `Request failed with status ${response.status}`);
+  }
+
+  if (!text) return null;
+
+  if (contentType.includes('application/json')) {
+    try {
+      return JSON.parse(text);
+    } catch (err) {
+      throw new Error('Failed to parse JSON response');
+    }
+  }
+
+  try {
+    return JSON.parse(text);
+  } catch (_) {
+    return text;
+  }
+}
+
+function resolveUrl(baseUrl, path) {
+  const normalizedBase = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+  const normalizedPath = path.startsWith('/') ? path.slice(1) : path;
+  return new URL(normalizedPath, normalizedBase).toString();
+}
+
+function formatDateTime(value) {
+  if (!value) return '—';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return String(value);
+  return `${date.toLocaleDateString([], { month: 'short', day: 'numeric' })} ${date.toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit'
+  })}`;
+}
+
+function formatTime(value) {
+  const date = value ? new Date(value) : new Date();
+  if (Number.isNaN(date.getTime())) return String(value);
+  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+}
+
+function formatJson(value) {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch (err) {
+    return String(value);
+  }
+}
+
+function escapeHtml(value) {
+  if (value === null || value === undefined) return '';
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function shortId(value) {
+  if (!value) return '—';
+  const str = String(value);
+  if (str.length <= 12) return str;
+  return `${str.slice(0, 6)}…${str.slice(-4)}`;
+}
+
+function sanitizeStatus(status) {
+  return String(status || 'unknown').toLowerCase().replace(/[^a-z0-9_-]/g, '-');
+}

--- a/dashboard-web/src/index.html
+++ b/dashboard-web/src/index.html
@@ -2,42 +2,711 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Personal AI Dashboard</title>
+    <title>Personal AI Orchestration Dashboard</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <style>
+      :root {
+        color-scheme: dark;
+        --bg: #0f172a;
+        --panel: #111c33;
+        --panel-border: rgba(148, 163, 184, 0.2);
+        --panel-shadow: 0 18px 45px rgba(15, 23, 42, 0.55);
+        --text: #e2e8f0;
+        --text-subtle: #94a3b8;
+        --accent: #38bdf8;
+        --accent-strong: #0ea5e9;
+        --danger: #f87171;
+        --warn: #fbbf24;
+        --success: #34d399;
+        --radius: 14px;
+        --mono: "SFMono-Regular", ui-monospace, SFMono-Regular, "SF Mono", Menlo, Monaco, Consolas,
+          "Liberation Mono", "Courier New", monospace;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
       body {
-        font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
         margin: 0;
-        padding: 2rem;
-        background: #0f172a;
-        color: #e2e8f0;
+        font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        background: radial-gradient(circle at 20% 20%, rgba(56, 189, 248, 0.08), transparent 60%),
+          radial-gradient(circle at 80% 0%, rgba(59, 130, 246, 0.12), transparent 55%), var(--bg);
+        color: var(--text);
+        min-height: 100vh;
       }
-      main {
-        max-width: 720px;
+
+      a {
+        color: var(--accent);
+      }
+
+      .app {
+        max-width: 1200px;
         margin: 0 auto;
+        padding: 2.5rem 1.5rem 4rem;
+        display: flex;
+        flex-direction: column;
+        gap: 1.75rem;
       }
-      h1 {
-        font-size: 2rem;
-        margin-bottom: 1rem;
+
+      header.app__header {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
       }
-      p {
+
+      header.app__header h1 {
+        font-size: clamp(1.85rem, 2vw + 1.2rem, 2.65rem);
+        font-weight: 600;
+        margin: 0;
+      }
+
+      header.app__header p {
+        margin: 0;
+        max-width: 720px;
+        color: var(--text-subtle);
         line-height: 1.6;
       }
-      code {
-        background: rgba(148, 163, 184, 0.25);
-        padding: 0.1rem 0.25rem;
-        border-radius: 0.25rem;
+
+      .status-banner {
+        padding: 0.75rem 1rem;
+        border-radius: var(--radius);
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        background: rgba(15, 23, 42, 0.65);
+        font-weight: 500;
+      }
+
+      .status-banner.status-ok {
+        border-color: rgba(52, 211, 153, 0.45);
+        background: rgba(52, 211, 153, 0.12);
+        color: #bbf7d0;
+      }
+
+      .status-banner.status-error {
+        border-color: rgba(248, 113, 113, 0.45);
+        background: rgba(248, 113, 113, 0.12);
+        color: #fecaca;
+      }
+
+      .status-banner.status-pending {
+        border-color: rgba(250, 204, 21, 0.45);
+        background: rgba(250, 204, 21, 0.12);
+        color: #fef3c7;
+      }
+
+      .panel {
+        background: linear-gradient(160deg, rgba(15, 23, 42, 0.85), rgba(15, 24, 52, 0.92));
+        border-radius: var(--radius);
+        border: 1px solid var(--panel-border);
+        box-shadow: var(--panel-shadow);
+        padding: 1.5rem;
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+      }
+
+      .panel__header {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        justify-content: space-between;
+        align-items: flex-end;
+      }
+
+      .panel__header h2 {
+        margin: 0;
+        font-size: 1.25rem;
+        font-weight: 600;
+      }
+
+      .panel__controls {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        align-items: center;
+      }
+
+      .panel__controls label {
+        flex-direction: row;
+        align-items: center;
+        gap: 0.5rem;
+      }
+
+      .panel__controls label span {
+        color: var(--text-subtle);
+        font-size: 0.9rem;
+      }
+
+      .form-grid {
+        display: grid;
+        gap: 1rem;
+      }
+
+      .form-grid.two-column {
+        grid-template-columns: minmax(0, 1fr);
+      }
+
+      @media (min-width: 720px) {
+        .form-grid.two-column {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+      }
+
+      label {
+        display: flex;
+        flex-direction: column;
+        gap: 0.45rem;
+        font-size: 0.95rem;
+      }
+
+      label span {
+        color: var(--text-subtle);
+      }
+
+      input[type='url'],
+      input[type='text'],
+      input[type='password'],
+      textarea,
+      select {
+        width: 100%;
+        padding: 0.6rem 0.75rem;
+        border-radius: 0.75rem;
+        border: 1px solid rgba(148, 163, 184, 0.25);
+        background: rgba(15, 23, 42, 0.65);
+        color: var(--text);
+        font-size: 0.95rem;
+        transition: border 0.2s ease, box-shadow 0.2s ease;
+      }
+
+      input:focus,
+      textarea:focus,
+      select:focus {
+        outline: none;
+        border-color: rgba(56, 189, 248, 0.55);
+        box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.25);
+      }
+
+      textarea {
+        min-height: 160px;
+        font-family: var(--mono);
+        line-height: 1.4;
+        resize: vertical;
+      }
+
+      .form-actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+      }
+
+      button.button {
+        border: none;
+        border-radius: 999px;
+        padding: 0.55rem 1.35rem;
+        font-size: 0.95rem;
+        font-weight: 500;
+        cursor: pointer;
+        transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+        background: rgba(148, 163, 184, 0.16);
+        color: var(--text);
+      }
+
+      button.button:hover:not(:disabled) {
+        transform: translateY(-1px);
+        box-shadow: 0 10px 25px rgba(15, 23, 42, 0.45);
+      }
+
+      button.button:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+      }
+
+      button.button.primary {
+        background: linear-gradient(120deg, rgba(56, 189, 248, 0.9), rgba(14, 165, 233, 0.9));
+        color: #0f172a;
+      }
+
+      button.button.ghost {
+        background: transparent;
+        border: 1px solid rgba(148, 163, 184, 0.3);
+      }
+
+      .hint {
+        margin: 0;
+        font-size: 0.85rem;
+        color: var(--text-subtle);
+      }
+
+      .feedback {
+        padding: 0.75rem 1rem;
+        border-radius: 0.85rem;
+        border: 1px solid rgba(148, 163, 184, 0.2);
+        background: rgba(15, 23, 42, 0.55);
+        font-size: 0.9rem;
+        display: none;
+      }
+
+      .feedback.is-visible {
+        display: block;
+      }
+
+      .feedback.success {
+        border-color: rgba(52, 211, 153, 0.45);
+        background: rgba(52, 211, 153, 0.1);
+        color: #bbf7d0;
+      }
+
+      .feedback.error {
+        border-color: rgba(248, 113, 113, 0.45);
+        background: rgba(248, 113, 113, 0.12);
+        color: #fecaca;
+      }
+
+      .panel-grid {
+        display: grid;
+        gap: 1.5rem;
+      }
+
+      @media (min-width: 960px) {
+        .panel-grid.two-column {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+      }
+
+      .table-wrapper {
+        overflow-x: auto;
+        border-radius: 0.75rem;
+        border: 1px solid rgba(148, 163, 184, 0.15);
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.9rem;
+      }
+
+      thead {
+        background: rgba(15, 23, 42, 0.75);
+      }
+
+      th,
+      td {
+        padding: 0.75rem 0.85rem;
+        text-align: left;
+        border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+      }
+
+      tbody tr:hover {
+        background: rgba(56, 189, 248, 0.08);
+      }
+
+      tbody tr.is-selected {
+        background: rgba(14, 165, 233, 0.18);
+      }
+
+      td .mono,
+      .mono {
+        font-family: var(--mono);
+      }
+
+      .pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        border-radius: 999px;
+        padding: 0.2rem 0.65rem;
+        font-size: 0.75rem;
+        letter-spacing: 0.02em;
+        text-transform: uppercase;
+        background: rgba(148, 163, 184, 0.18);
+        border: 1px solid rgba(148, 163, 184, 0.28);
+      }
+
+      .pill.status-queued {
+        border-color: rgba(250, 204, 21, 0.45);
+        background: rgba(250, 204, 21, 0.1);
+        color: #fde68a;
+      }
+
+      .pill.status-running {
+        border-color: rgba(56, 189, 248, 0.45);
+        background: rgba(56, 189, 248, 0.15);
+        color: #bae6fd;
+      }
+
+      .pill.status-done {
+        border-color: rgba(52, 211, 153, 0.45);
+        background: rgba(52, 211, 153, 0.15);
+        color: #bbf7d0;
+      }
+
+      .pill.status-error {
+        border-color: rgba(248, 113, 113, 0.45);
+        background: rgba(248, 113, 113, 0.15);
+        color: #fecaca;
+      }
+
+      .pill.status-ok {
+        border-color: rgba(52, 211, 153, 0.45);
+        background: rgba(52, 211, 153, 0.12);
+        color: #bbf7d0;
+      }
+
+      .pill.status-unknown {
+        border-color: rgba(148, 163, 184, 0.35);
+        background: rgba(148, 163, 184, 0.15);
+        color: var(--text-subtle);
+      }
+
+      .pill.log-level-info {
+        border-color: rgba(56, 189, 248, 0.35);
+        background: rgba(56, 189, 248, 0.12);
+        color: #bae6fd;
+      }
+
+      .pill.log-level-warn {
+        border-color: rgba(250, 204, 21, 0.45);
+        background: rgba(250, 204, 21, 0.12);
+        color: #fef3c7;
+      }
+
+      .pill.log-level-error {
+        border-color: rgba(248, 113, 113, 0.45);
+        background: rgba(248, 113, 113, 0.12);
+        color: #fecaca;
+      }
+
+      .timeline {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 0.95rem;
+      }
+
+      .timeline__item {
+        display: grid;
+        grid-template-columns: auto minmax(0, 1fr);
+        gap: 0.85rem;
+      }
+
+      .timeline__item--empty {
+        grid-template-columns: minmax(0, 1fr);
+        color: var(--text-subtle);
+      }
+
+      .timeline__ts {
+        font-family: var(--mono);
+        font-size: 0.8rem;
+        color: var(--text-subtle);
+        padding-top: 0.15rem;
+      }
+
+      .timeline__content {
+        background: rgba(15, 23, 42, 0.6);
+        border-radius: 0.85rem;
+        border: 1px solid rgba(148, 163, 184, 0.12);
+        padding: 0.85rem 1rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+      }
+
+      .timeline__label {
+        font-weight: 500;
+      }
+
+      .timeline__text {
+        margin: 0;
+        color: var(--text-subtle);
+        font-size: 0.88rem;
+        line-height: 1.5;
+      }
+
+      .timeline__details summary {
+        cursor: pointer;
+        font-size: 0.85rem;
+        color: var(--accent);
+      }
+
+      .timeline__details pre,
+      pre.json-block {
+        margin: 0;
+        background: rgba(15, 23, 42, 0.6);
+        border-radius: 0.65rem;
+        border: 1px solid rgba(148, 163, 184, 0.15);
+        padding: 0.75rem;
+        font-family: var(--mono);
+        font-size: 0.78rem;
+        white-space: pre-wrap;
+        word-break: break-word;
+      }
+
+      .detail-meta {
+        display: grid;
+        gap: 0.75rem;
+        font-size: 0.9rem;
+      }
+
+      .detail-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+      }
+
+      .detail-row span.label {
+        color: var(--text-subtle);
+        min-width: 120px;
+      }
+
+      .detail-actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+      }
+
+      .detail-section {
+        display: flex;
+        flex-direction: column;
+        gap: 0.6rem;
+      }
+
+      .detail-section h3 {
+        margin: 0;
+        font-size: 1rem;
+        font-weight: 600;
+      }
+
+      .config-results {
+        display: grid;
+        gap: 1rem;
+      }
+
+      @media (min-width: 780px) {
+        .config-results {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+      }
+
+      .config-card {
+        border-radius: 1rem;
+        border: 1px solid rgba(148, 163, 184, 0.15);
+        background: rgba(15, 23, 42, 0.55);
+        padding: 1rem 1.25rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+      }
+
+      .config-card__header {
+        display: flex;
+        justify-content: space-between;
+        gap: 0.75rem;
+      }
+
+      .config-card__header h3 {
+        margin: 0;
+        font-size: 1.05rem;
+      }
+
+      .config-card__url {
+        margin: 0;
+        color: var(--text-subtle);
+        font-size: 0.82rem;
+        word-break: break-all;
+      }
+
+      .config-card--error {
+        border-color: rgba(248, 113, 113, 0.35);
+        background: rgba(248, 113, 113, 0.08);
+      }
+
+      ul.bullet-list {
+        margin: 0;
+        padding-left: 1.1rem;
+        color: var(--text-subtle);
+        font-size: 0.85rem;
+      }
+
+      footer {
+        text-align: center;
+        color: var(--text-subtle);
+        font-size: 0.85rem;
+      }
+
+      footer a {
+        color: var(--accent);
       }
     </style>
   </head>
   <body>
-    <main>
-      <h1>Personal AI Orchestration Dashboard</h1>
-      <p>
-        This is a placeholder static build. Replace <code>dashboard-web/src</code> with the actual
-        single-page application and run <code>npm run build --prefix dashboard-web</code> to produce the
-        deployable assets in <code>dashboard-web/dist</code>.
-      </p>
-    </main>
+    <div class="app">
+      <header class="app__header">
+        <h1>Personal AI Orchestration Dashboard</h1>
+        <p>
+          Monitor task lifecycles, follow log streams, trigger manual jobs, and verify configuration health for all Render-bound
+          services from a single control surface.
+        </p>
+        <div id="status-banner" class="status-banner" role="status" aria-live="polite">Not connected.</div>
+      </header>
+
+      <section class="panel" id="connection-panel">
+        <div class="panel__header">
+          <h2>Connection</h2>
+        </div>
+        <form id="connection-form" class="form-grid two-column" autocomplete="off">
+          <label>
+            <span>Orchestrator URL *</span>
+            <input type="url" id="orchestrator-url" name="orchestratorUrl" required placeholder="http://localhost:4000" />
+          </label>
+          <label>
+            <span>Logging URL</span>
+            <input type="url" id="logging-url" name="loggingUrl" placeholder="http://localhost:4001" />
+          </label>
+          <label>
+            <span>Echo agent URL</span>
+            <input type="url" id="echo-url" name="echoUrl" placeholder="http://localhost:4002" />
+          </label>
+          <label>
+            <span>Render control URL</span>
+            <input type="url" id="renderctl-url" name="renderctlUrl" placeholder="http://localhost:4003" />
+          </label>
+          <label>
+            <span>Basic Auth username</span>
+            <input type="text" id="auth-username" name="username" autocomplete="username" placeholder="operator" />
+          </label>
+          <label>
+            <span>Basic Auth password</span>
+            <input type="password" id="auth-password" name="password" autocomplete="current-password" />
+          </label>
+          <div class="form-actions">
+            <button type="submit" class="button primary" id="connect-button">Connect</button>
+            <button type="button" class="button" id="disconnect-button">Disconnect</button>
+            <button type="button" class="button ghost" id="clear-settings">Clear saved settings</button>
+          </div>
+        </form>
+        <p class="hint">Credentials are kept in-memory only. Base URLs and username are cached in local storage for convenience.</p>
+      </section>
+
+      <section class="panel" id="task-creator">
+        <div class="panel__header">
+          <h2>Create Task</h2>
+        </div>
+        <form id="task-form" class="form-grid two-column">
+          <label>
+            <span>Task type</span>
+            <input type="text" id="task-type" name="type" value="echo" required />
+          </label>
+          <label>
+            <span>Source</span>
+            <input type="text" id="task-source" name="source" value="dashboard" required />
+          </label>
+          <label>
+            <span>Correlation ID</span>
+            <input type="text" id="task-correlation" name="correlationId" placeholder="optional" />
+          </label>
+          <label class="textarea">
+            <span>Payload (JSON)</span>
+            <textarea id="task-payload" name="payload"></textarea>
+          </label>
+          <div class="form-actions">
+            <button type="submit" class="button primary">Enqueue task</button>
+            <button type="button" class="button ghost" id="reset-payload">Reset payload</button>
+          </div>
+        </form>
+        <div id="task-feedback" class="feedback" role="status" aria-live="polite"></div>
+      </section>
+
+      <section class="panel" id="tasks-panel">
+        <div class="panel__header">
+          <h2>Recent Tasks</h2>
+          <div class="panel__controls">
+            <label>
+              <span>Status</span>
+              <select id="task-filter" name="taskFilter">
+                <option value="all">All</option>
+                <option value="queued">Queued</option>
+                <option value="running">Running</option>
+                <option value="done">Done</option>
+                <option value="error">Error</option>
+              </select>
+            </label>
+            <button type="button" class="button" id="refresh-tasks">Refresh</button>
+          </div>
+        </div>
+        <div class="table-wrapper">
+          <table id="tasks-table">
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>Status</th>
+                <th>Type</th>
+                <th>Source</th>
+                <th>Updated</th>
+                <th>Version</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody id="tasks-tbody">
+              <tr class="empty">
+                <td colspan="7">No tasks yet. Create one above to get started.</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="panel" id="task-detail-panel">
+        <div class="panel__header">
+          <h2>Task detail</h2>
+          <div class="panel__controls">
+            <button type="button" class="button" id="refresh-detail">Refresh detail</button>
+          </div>
+        </div>
+        <div id="task-detail" class="detail-body">
+          <p class="hint">Select a task from the table to inspect payloads, results, and event history.</p>
+        </div>
+      </section>
+
+      <div class="panel-grid two-column">
+        <section class="panel" id="activity-panel">
+          <div class="panel__header">
+            <h2>Activity stream</h2>
+          </div>
+          <ul id="activity-list" class="timeline">
+            <li class="timeline__item timeline__item--empty">No activity yet.</li>
+          </ul>
+        </section>
+
+        <section class="panel" id="logs-panel">
+          <div class="panel__header">
+            <h2>Latest logs</h2>
+          </div>
+          <ul id="logs-list" class="timeline">
+            <li class="timeline__item timeline__item--empty">No logs yet.</li>
+          </ul>
+        </section>
+      </div>
+
+      <section class="panel" id="config-panel">
+        <div class="panel__header">
+          <h2>Configuration health</h2>
+          <div class="panel__controls">
+            <button type="button" class="button" id="refresh-config">Run validation</button>
+          </div>
+        </div>
+        <div id="config-results" class="config-results">
+          <p class="hint">Provide base URLs above and run validation to inspect each service's configuration status.</p>
+        </div>
+      </section>
+
+      <footer>
+        Built for Render-native agent orchestration. Review the <a href="../docs/product-requirements.md">product requirements</a>
+        for the complete roadmap.
+      </footer>
+    </div>
+
+    <script type="module" src="./app.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the placeholder dashboard with a full dark-themed control surface that covers connection settings, task creation, task monitoring, activity, logs, and config validation views
- add a client-side app module to manage Basic Auth credentials, fetch orchestrator/logging data, handle WebSocket activity, and render task/detail/log/config panels with live updates and local storage helpers
- enhance styling tokens (status chips, timelines, config cards) to accommodate the richer UI states

## Testing
- npm run --prefix dashboard-web build

------
https://chatgpt.com/codex/tasks/task_e_68cae720504883308dd75625f7164ef1